### PR TITLE
feat(add-to/cart): Let it be shown for unavailable products

### DIFF
--- a/view/frontend/layout/product_tile.xml
+++ b/view/frontend/layout/product_tile.xml
@@ -194,6 +194,7 @@
 
                             <block class="MageSuite\ProductTile\Block\Tile\Fragment" name="product.tile.addtocart" template="MageSuite_ProductTile::fragments/add-to/cart.phtml">
                                 <arguments>
+                                    <argument xsi:type="boolean" name="show_for_unavailable_products">false</argument>
                                     <argument xsi:type="boolean" name="show_only_for_simple_products">false</argument>
                                     <argument xsi:type="string" name="form_class">cs-addtocart cs-product-tile__addtocart</argument>
                                     <argument xsi:type="string" name="atc_add_label" translate="true">Add to Cart</argument>

--- a/view/frontend/templates/fragments/add-to/cart.phtml
+++ b/view/frontend/templates/fragments/add-to/cart.phtml
@@ -15,10 +15,16 @@
 ?>
 
 <?php
-    if ($isSaleable && (!$showOnlyForSimpleProducts || $showOnlyForSimpleProducts && $productTypeId == \Magento\Catalog\Model\Product\Type::TYPE_SIMPLE)): ?>
+    if (
+        $block->getShowForUnavailableProducts()
+        || $isSaleable && (
+            !$showOnlyForSimpleProducts
+            || $showOnlyForSimpleProducts && $productTypeId == \Magento\Catalog\Model\Product\Type::TYPE_SIMPLE
+        )
+    ): ?>
         <?php $postParams = $block->getAddToCartPostParams($product); ?>
 
-        <form<?php if(!$canBeConfigured): ?> data-role="tocart-form"<?php endif; ?> data-product-sku="<?= $block->escapeHtml($product->getSku()) ?>" action="<?= /* @NoEscape */ $postParams['action'] ?>" method="post" class="<?= $block->getFormClass() ?>"
+        <form<?php if(!$canBeConfigured): ?> data-role="tocart-form"<?php endif; ?> data-product-sku="<?= $block->escapeHtml($product->getSku()) ?>" action="<?= /* @NoEscape */ $postParams['action'] ?>" method="post" class="<?= $block->getFormClass() . ( $isSaleable ? '' : ' cs-addtocart--unavailable') ?>"
             <?php if (!$block->isRedirectToCartEnabled() && $block->getVar('ajax_addtocart/enabled', 'Magento_Catalog')): ?>
                 data-mage-init='{"catalogAddToCart": {}}'
             <?php endif; ?>


### PR DESCRIPTION
If the button is shown in some tiles and in some not, and if the button affects the dimensions of the tile (e.g. when it's shown as a additional block in the bottom of the tile, extending its' height), it will cause some tiles to be taller than the others.

An example of that can be seen on the screenshot below - unavailable products have their title not aligned with the available products:

<img width="925" alt="image" src="https://user-images.githubusercontent.com/1862580/231573549-c5f84f65-d45b-46ac-8840-724267dabd42.png">


This commit allows the dev to enforce the button to be shown for all products (including unavailable ones) by setting an option in xml (and styling it differently through css, when the product is unavailable).